### PR TITLE
feat: støtter Python 3.10 også

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,11 +5,14 @@ on: push
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.version }}
       - run: pip3 install poetry
       - run: poetry install --with test
       - run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 apache-airflow-providers-cncf-kubernetes = "^7.6.0"
 kubernetes = ">=21.7.0,<24"
 pathlib = "^1.0.1"
-python = "^3.11"
+python = "^3.10"
 apache-airflow-providers-slack = "^8.1.0"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Airflow bruker fortsatt 3.10, så kan ikke bumpe til 3.11 helt enda.